### PR TITLE
Tailwind CSSのhover:scale-102エラー修正（hover:scale-105へ変更）

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,7 +26,7 @@
   }
   
   .music-card {
-    @apply glass-card p-4 hover:bg-white/20 transition-all duration-300 transform hover:scale-102;
+    @apply glass-card p-4 hover:bg-white/20 transition-all duration-300 transform hover:scale-105;
   }
 }
 


### PR DESCRIPTION
Tailwind CSSのクラス指定ミス（hover:scale-102）をhover:scale-105へ修正しました。

- globals.cssの該当箇所を修正
- ローカルでエラーが解消されていることを確認済み

ご確認よろしくお願いします。